### PR TITLE
Sync stamp msgs with source

### DIFF
--- a/optitrack_tf/broadcast_tf.py
+++ b/optitrack_tf/broadcast_tf.py
@@ -50,7 +50,7 @@ class OptitrackTFPublisher(Node):
         It publishes the tf messages by the tf_broadcaster.
         """
         t = TransformStamped()
-        t.header.stamp = self.get_clock().now().to_msg()
+        t.header.stamp = msg.header.stamp  # Take over stamp time from data source
         t.header.frame_id = 'world'
         t.child_frame_id = self.tracker_name
 


### PR DESCRIPTION
Previously, the time stamp was made based on current time. For messages from rosbags, this would throw the messages out of sync from the original messages. Even for online message processing, a small delay would be introduced.